### PR TITLE
Add hardcoded swedish subs to tv4 extractor

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -1784,7 +1784,7 @@ class InfoExtractor(object):
 
     def _parse_m3u8_subtitles(self, m3u8_doc, m3u8_url):
         """
-        Parse subtitles from m3u8 file. 
+        Parse subtitles from m3u8 file.
         Please avoid downloading the m3u8 twice.
         """
         format_url = lambda u: (

--- a/youtube_dl/extractor/tv4.py
+++ b/youtube_dl/extractor/tv4.py
@@ -107,11 +107,21 @@ class TV4IE(InfoExtractor):
 
         self._sort_formats(formats)
 
+        # The subtitles are defined in the manifest_url like this:
+        # # SUBTITLES groups
+        # #EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="textstream",NAME="Swedish",LANGUAGE="sv",AUTOSELECT=YES,DEFAULT=YES,URI="bmetgl4z0mr(12579349_ISMUSP)-textstream_swe=3000.m3u8"
+        # but I don't know yet how to extract it dynamically from there so they are hardcoded as a start.
+        hardcoded_swedish_subs_url = manifest_url[:-5] + "-textstream_swe=3000.webvtt"
+        subtitles = {}
+        subtitles.setdefault('sv', []).append({
+            'url': hardcoded_swedish_subs_url,
+            'ext': 'vtt'})
+        
         return {
             'id': video_id,
             'title': title,
             'formats': formats,
-            # 'subtitles': subtitles,
+            'subtitles': subtitles,
             'description': info.get('description'),
             'timestamp': parse_iso8601(info.get('broadcast_date_time')),
             'duration': int_or_none(info.get('duration')),

--- a/youtube_dl/extractor/tv4.py
+++ b/youtube_dl/extractor/tv4.py
@@ -119,7 +119,6 @@ class TV4IE(InfoExtractor):
 
         if res:
             m3u8_doc, urlh = res
-            m3u8_url = urlh.geturl()
             subtitles = self._parse_m3u8_subtitles(m3u8_doc, manifest_url)
             # Hardcode webvtt for now
             for item in subtitles:

--- a/youtube_dl/extractor/tv4.py
+++ b/youtube_dl/extractor/tv4.py
@@ -115,8 +115,9 @@ class TV4IE(InfoExtractor):
         subtitles = {}
         subtitles.setdefault('sv', []).append({
             'url': hardcoded_swedish_subs_url,
-            'ext': 'vtt'})
-        
+            'ext': 'vtt'
+        })
+
         return {
             'id': video_id,
             'title': title,


### PR DESCRIPTION
If anyone know how to extract it dynamically then feel free to give me a tip or improve it before merging it in.

        # The subtitles are defined in the manifest_url like this:
        # # SUBTITLES groups
        # #EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="textstream",NAME="Swedish",LANGUAGE="sv",AUTOSELECT=YES,DEFAULT=YES,URI="bmetgl4z0mr(12579349_ISMUSP)-textstream_swe=3000.m3u8"
        # but I don't know yet how to extract it dynamically from there so they are hardcoded as a start.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.
